### PR TITLE
route writeback through Legion::Apollo.ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.9] - 2026-03-25
+
+### Changed
+- `Helpers::Writeback#write_directly` now routes through `Legion::Apollo.ingest` when the core library is loaded, falling back to `Runners::Knowledge.handle_ingest` for backward compatibility when it is not
+
 ## [0.4.8] - 2026-03-25
 
 ### Changed

--- a/lib/legion/extensions/apollo/helpers/writeback.rb
+++ b/lib/legion/extensions/apollo/helpers/writeback.rb
@@ -77,7 +77,11 @@ module Legion
           end
 
           def write_directly(payload)
-            Runners::Knowledge.handle_ingest(**payload)
+            if defined?(Legion::Apollo)
+              Legion::Apollo.ingest(**payload)
+            else
+              Runners::Knowledge.handle_ingest(**payload)
+            end
           rescue StandardError => e
             Legion::Logging.warn("apollo direct write failed, falling back to transport: #{e.message}") if defined?(Legion::Logging)
             publish_to_transport(payload, has_embedding: !payload[:embedding].nil?)

--- a/lib/legion/extensions/apollo/version.rb
+++ b/lib/legion/extensions/apollo/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Apollo
-      VERSION = '0.4.8'
+      VERSION = '0.4.9'
     end
   end
 end

--- a/spec/legion/extensions/apollo/helpers/writeback_spec.rb
+++ b/spec/legion/extensions/apollo/helpers/writeback_spec.rb
@@ -80,6 +80,68 @@ RSpec.describe Legion::Extensions::Apollo::Helpers::Writeback do
     end
   end
 
+  describe '.write_directly' do
+    let(:payload) do
+      {
+        content:      'test content for ingest',
+        tags:         %w[test ruby],
+        content_type: 'observation',
+        embedding:    Array.new(1024, 0.1)
+      }
+    end
+
+    context 'when Legion::Apollo is defined' do
+      before do
+        stub_const('Legion::Apollo', Module.new)
+        allow(Legion::Apollo).to receive(:ingest)
+      end
+
+      it 'routes through Legion::Apollo.ingest' do
+        described_class.write_directly(payload)
+        expect(Legion::Apollo).to have_received(:ingest).with(**payload)
+      end
+
+      it 'does not call Runners::Knowledge.handle_ingest directly' do
+        knowledge_mod = Module.new { def self.handle_ingest(**_); end }
+        stub_const('Legion::Extensions::Apollo::Runners', Module.new)
+        stub_const('Legion::Extensions::Apollo::Runners::Knowledge', knowledge_mod)
+        allow(knowledge_mod).to receive(:handle_ingest)
+        described_class.write_directly(payload)
+        expect(knowledge_mod).not_to have_received(:handle_ingest)
+      end
+    end
+
+    context 'when Legion::Apollo is not defined' do
+      let(:knowledge_mod) { Module.new { def self.handle_ingest(**_); end } }
+
+      before do
+        hide_const('Legion::Apollo') if defined?(Legion::Apollo)
+        stub_const('Legion::Extensions::Apollo::Runners', Module.new)
+        stub_const('Legion::Extensions::Apollo::Runners::Knowledge', knowledge_mod)
+        allow(knowledge_mod).to receive(:handle_ingest)
+      end
+
+      it 'falls back to Runners::Knowledge.handle_ingest' do
+        described_class.write_directly(payload)
+        expect(knowledge_mod).to have_received(:handle_ingest).with(**payload)
+      end
+    end
+
+    context 'when an error is raised' do
+      before do
+        stub_const('Legion::Apollo', Module.new)
+        allow(Legion::Apollo).to receive(:ingest).and_raise(StandardError, 'boom')
+        allow(described_class).to receive(:publish_to_transport)
+      end
+
+      it 'falls back to publish_to_transport' do
+        described_class.write_directly(payload)
+        expect(described_class).to have_received(:publish_to_transport)
+          .with(payload, has_embedding: true)
+      end
+    end
+  end
+
   describe '.content_hash' do
     it 'produces consistent hashes for same content' do
       hash1 = described_class.content_hash('hello world')


### PR DESCRIPTION
## Summary
- Migrates `Helpers::Writeback#write_directly` to route through `Legion::Apollo.ingest` instead of calling `Runners::Knowledge.handle_ingest` directly
- Falls back to direct runner call when `legion-apollo` core library is not loaded
- Adds 3 specs covering the routing logic

Closes #8

## Changes
- `lib/legion/extensions/apollo/helpers/writeback.rb` — `write_directly` checks `defined?(Legion::Apollo)` first
- `spec/legion/extensions/apollo/helpers/writeback_spec.rb` — 3 new contexts for `write_directly`
- Version bump 0.4.8 → 0.4.9

## Test Coverage
- 14 specs passing
- `bundle exec rubocop` — zero offenses