### PR TITLE
fix handle_ingest keyword args and local dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.11] - 2026-03-27
+
+### Fixed
+- `handle_ingest`: made `content:` and `content_type:` optional with nil defaults, added `skip:` parameter for GAIA dream cycle phase wiring compatibility
+
 ## [0.4.10] - 2026-03-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.10] - 2026-03-26
+
+### Changed
+- set remote_invocable? false for local dispatch
+
 ## [0.4.9] - 2026-03-25
 
 ### Changed

--- a/lib/legion/extensions/apollo.rb
+++ b/lib/legion/extensions/apollo.rb
@@ -33,6 +33,10 @@ module Legion
   module Extensions
     module Apollo
       extend Legion::Extensions::Core if Legion::Extensions.const_defined? :Core
+
+      def self.remote_invocable?
+        false
+      end
     end
   end
 end

--- a/lib/legion/extensions/apollo/runners/knowledge.rb
+++ b/lib/legion/extensions/apollo/runners/knowledge.rb
@@ -58,7 +58,10 @@ module Legion
             }
           end
 
-          def handle_ingest(content:, content_type:, tags: [], source_agent: 'unknown', source_provider: nil, source_channel: nil, knowledge_domain: nil, submitted_by: nil, submitted_from: nil, content_hash: nil, context: {}, **) # rubocop:disable Metrics/ParameterLists, Layout/LineLength
+          def handle_ingest(content: nil, content_type: nil, tags: [], source_agent: 'unknown', source_provider: nil, source_channel: nil, knowledge_domain: nil, submitted_by: nil, submitted_from: nil, content_hash: nil, context: {}, skip: false, **) # rubocop:disable Metrics/ParameterLists, Layout/LineLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+            return { status: :skipped } if skip
+            return { success: false, error: 'content is required' } if content.nil? || content.to_s.strip.empty?
+            return { success: false, error: 'content_type is required' } if content_type.nil?
             return { success: false, error: 'apollo_data_not_available' } unless defined?(Legion::Data::Model::ApolloEntry)
 
             # Content hash dedup

--- a/lib/legion/extensions/apollo/version.rb
+++ b/lib/legion/extensions/apollo/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Apollo
-      VERSION = '0.4.9'
+      VERSION = '0.4.10'
     end
   end
 end

--- a/lib/legion/extensions/apollo/version.rb
+++ b/lib/legion/extensions/apollo/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Apollo
-      VERSION = '0.4.10'
+      VERSION = '0.4.11'
     end
   end
 end


### PR DESCRIPTION
## Summary
- `handle_ingest`: made `content:` and `content_type:` optional with nil defaults, added `skip:` parameter for GAIA dream cycle `knowledge_promotion` phase compatibility
- Route writeback through `Legion::Apollo.ingest` (#7)
- Set `remote_invocable? false` for local dispatch

## Versions
- 0.4.9 → 0.4.11

## Test plan
- [x] `bundle exec rspec` — 293 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses