### PR TITLE
feat: rename apollo exchange/queues to legion.apollo. prefix (v3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.15] - 2026-03-28
+
+### Changed
+- Update exchange name from `apollo` to `legion.apollo` (unified naming convention)
+- Update all queue names to use `legion.apollo.` prefix (ingest, query, writeback.store, writeback.vectorize, gas)
+- Update all DLX references from `apollo.dlx` to `legion.apollo.dlx`
+- Update all message routing keys to use `legion.apollo.` prefix
+
 ## [0.4.14] - 2026-03-27
 
 ### Fixed

--- a/lib/legion/extensions/apollo/transport/exchanges/apollo.rb
+++ b/lib/legion/extensions/apollo/transport/exchanges/apollo.rb
@@ -9,7 +9,7 @@ module Legion
         module Exchanges
           class Apollo < Legion::Transport::Exchange
             def exchange_name
-              'apollo'
+              'legion.apollo'
             end
           end
         end

--- a/lib/legion/extensions/apollo/transport/messages/ingest.rb
+++ b/lib/legion/extensions/apollo/transport/messages/ingest.rb
@@ -13,7 +13,7 @@ module Legion
             end
 
             def routing_key
-              'apollo.ingest'
+              'legion.apollo.ingest'
             end
 
             def message

--- a/lib/legion/extensions/apollo/transport/messages/query.rb
+++ b/lib/legion/extensions/apollo/transport/messages/query.rb
@@ -13,7 +13,7 @@ module Legion
             end
 
             def routing_key
-              'apollo.query'
+              'legion.apollo.query'
             end
 
             def message

--- a/lib/legion/extensions/apollo/transport/messages/writeback.rb
+++ b/lib/legion/extensions/apollo/transport/messages/writeback.rb
@@ -13,7 +13,7 @@ module Legion
             end
 
             def routing_key
-              @options[:has_embedding] ? 'apollo.writeback.store' : 'apollo.writeback.vectorize'
+              @options[:has_embedding] ? 'legion.apollo.writeback.store' : 'legion.apollo.writeback.vectorize'
             end
 
             def type

--- a/lib/legion/extensions/apollo/transport/queues/gas.rb
+++ b/lib/legion/extensions/apollo/transport/queues/gas.rb
@@ -9,11 +9,11 @@ module Legion
         module Queues
           class GasSubscriber < Legion::Transport::Queue
             def queue_name
-              'apollo.gas'
+              'legion.apollo.gas'
             end
 
             def queue_options
-              { manual_ack: true, durable: true, arguments: { 'x-dead-letter-exchange': 'apollo.dlx' } }
+              { manual_ack: true, durable: true, arguments: { 'x-dead-letter-exchange': 'legion.apollo.dlx' } }
             end
           end
         end

--- a/lib/legion/extensions/apollo/transport/queues/ingest.rb
+++ b/lib/legion/extensions/apollo/transport/queues/ingest.rb
@@ -9,11 +9,11 @@ module Legion
         module Queues
           class Ingest < Legion::Transport::Queue
             def queue_name
-              'apollo.ingest'
+              'legion.apollo.ingest'
             end
 
             def queue_options
-              { manual_ack: true, durable: true, arguments: { 'x-dead-letter-exchange': 'apollo.dlx' } }
+              { manual_ack: true, durable: true, arguments: { 'x-dead-letter-exchange': 'legion.apollo.dlx' } }
             end
           end
         end

--- a/lib/legion/extensions/apollo/transport/queues/query.rb
+++ b/lib/legion/extensions/apollo/transport/queues/query.rb
@@ -9,11 +9,11 @@ module Legion
         module Queues
           class QueryResponder < Legion::Transport::Queue
             def queue_name
-              'apollo.query'
+              'legion.apollo.query'
             end
 
             def queue_options
-              { manual_ack: true, durable: true, arguments: { 'x-dead-letter-exchange': 'apollo.dlx' } }
+              { manual_ack: true, durable: true, arguments: { 'x-dead-letter-exchange': 'legion.apollo.dlx' } }
             end
           end
         end

--- a/lib/legion/extensions/apollo/transport/queues/writeback_store.rb
+++ b/lib/legion/extensions/apollo/transport/queues/writeback_store.rb
@@ -9,11 +9,11 @@ module Legion
         module Queues
           class WritebackStore < Legion::Transport::Queue
             def queue_name
-              'apollo.writeback.store'
+              'legion.apollo.writeback.store'
             end
 
             def queue_options
-              { manual_ack: true, durable: true, arguments: { 'x-dead-letter-exchange': 'apollo.dlx' } }
+              { manual_ack: true, durable: true, arguments: { 'x-dead-letter-exchange': 'legion.apollo.dlx' } }
             end
           end
         end

--- a/lib/legion/extensions/apollo/transport/queues/writeback_vectorize.rb
+++ b/lib/legion/extensions/apollo/transport/queues/writeback_vectorize.rb
@@ -9,11 +9,11 @@ module Legion
         module Queues
           class WritebackVectorize < Legion::Transport::Queue
             def queue_name
-              'apollo.writeback.vectorize'
+              'legion.apollo.writeback.vectorize'
             end
 
             def queue_options
-              { manual_ack: true, durable: true, arguments: { 'x-dead-letter-exchange': 'apollo.dlx' } }
+              { manual_ack: true, durable: true, arguments: { 'x-dead-letter-exchange': 'legion.apollo.dlx' } }
             end
           end
         end

--- a/lib/legion/extensions/apollo/version.rb
+++ b/lib/legion/extensions/apollo/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Apollo
-      VERSION = '0.4.14'
+      VERSION = '0.4.15'
     end
   end
 end

--- a/spec/legion/extensions/apollo/transport/messages/ingest_spec.rb
+++ b/spec/legion/extensions/apollo/transport/messages/ingest_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Legion::Extensions::Apollo::Transport::Messages::Ingest do
   end
 
   describe '#routing_key' do
-    it 'returns apollo.ingest' do
-      expect(message.routing_key).to eq('apollo.ingest')
+    it 'returns legion.apollo.ingest' do
+      expect(message.routing_key).to eq('legion.apollo.ingest')
     end
   end
 

--- a/spec/legion/extensions/apollo/transport/messages/query_spec.rb
+++ b/spec/legion/extensions/apollo/transport/messages/query_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe Legion::Extensions::Apollo::Transport::Messages::Query do
   end
 
   describe '#routing_key' do
-    it 'returns apollo.query' do
-      expect(message.routing_key).to eq('apollo.query')
+    it 'returns legion.apollo.query' do
+      expect(message.routing_key).to eq('legion.apollo.query')
     end
   end
 

--- a/spec/legion/extensions/apollo/transport/messages/writeback_spec.rb
+++ b/spec/legion/extensions/apollo/transport/messages/writeback_spec.rb
@@ -41,12 +41,12 @@ RSpec.describe Legion::Extensions::Apollo::Transport::Messages::Writeback do
   describe '#routing_key' do
     it 'routes to store when embedding present' do
       msg = described_class.new(**base_opts, has_embedding: true, embedding: [0.1] * 1024)
-      expect(msg.routing_key).to eq('apollo.writeback.store')
+      expect(msg.routing_key).to eq('legion.apollo.writeback.store')
     end
 
     it 'routes to vectorize when no embedding' do
       msg = described_class.new(**base_opts, has_embedding: false)
-      expect(msg.routing_key).to eq('apollo.writeback.vectorize')
+      expect(msg.routing_key).to eq('legion.apollo.writeback.vectorize')
     end
   end
 


### PR DESCRIPTION
## Summary

Renames all Apollo AMQP topology from bare `apollo.*` names to `legion.apollo.*` to align with the v3.0 library-gem naming convention (`legion.{gem_name}` prefix for library gem exchanges and queues).

### Changes
- `Transport::Exchanges::Apollo#exchange_name`: `'apollo'` → `'legion.apollo'`
- `Transport::Messages::Ingest#routing_key`: `'apollo.ingest'` → `'legion.apollo.ingest'`
- `Transport::Messages::Query#routing_key`: `'apollo.query'` → `'legion.apollo.query'`
- `Transport::Messages::Writeback#routing_key`: `'apollo.writeback.store'`/`'apollo.writeback.vectorize'` → `'legion.apollo.writeback.store'`/`'legion.apollo.writeback.vectorize'`
- All queue files: `queue_name`, DLX references updated from `apollo.*` → `legion.apollo.*`
- All spec routing key expectations updated

### Version
`0.4.14` → `0.4.15`

## Test Plan
- [ ] `bundle exec rspec` — 293 examples, 0 failures (verified)
- [ ] `bundle exec rubocop` — 72 files, 0 offenses (verified)
- [ ] Verify `Legion::Extensions::Apollo::Transport::Exchanges::Apollo.new.exchange_name` returns `'legion.apollo'`
- [ ] Verify ingest/query/writeback routing keys match `legion.apollo.*` pattern