### PR TITLE
add rubocop-legion plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   ci:
     uses: LegionIO/.github/.github/workflows/ci.yml@main
 
-  lint:
-    uses: LegionIO/.github/.github/workflows/lint-patterns.yml@main
+  excluded-files:
+    uses: LegionIO/.github/.github/workflows/excluded-files.yml@main
 
   security:
     uses: LegionIO/.github/.github/workflows/security-scan.yml@main
@@ -27,7 +27,7 @@ jobs:
     uses: LegionIO/.github/.github/workflows/stale.yml@main
 
   release:
-    needs: [ci, lint]
+    needs: [ci, excluded-files]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: LegionIO/.github/.github/workflows/release.yml@main
     secrets:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,59 +1,39 @@
-AllCops:
-  TargetRubyVersion: 3.4
-  NewCops: enable
-  SuggestExtensions: false
+inherit_gem:
+  rubocop-legion: config/lex.yml
 
-Layout/LineLength:
-  Max: 160
-
-Layout/SpaceAroundEqualsInParameterDefault:
-  EnforcedStyle: space
-
-Layout/HashAlignment:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
-
-Metrics/MethodLength:
-  Max: 50
-
-Metrics/ClassLength:
-  Max: 1500
-
-Metrics/ModuleLength:
-  Max: 1500
-
-Metrics/BlockLength:
-  Max: 40
-  Exclude:
-    - 'spec/**/*'
-
-Metrics/AbcSize:
-  Max: 60
-
-Metrics/ParameterLists:
-  Max: 6
-
-Metrics/CyclomaticComplexity:
-  Max: 15
-
-Metrics/PerceivedComplexity:
-  Max: 17
-
-Style/Documentation:
+# Actors use modern Ruby one-liner `def time = N` syntax which this cop does not recognize
+Legion/Extension/EveryActorRequiresTime:
   Enabled: false
 
-Style/SymbolArray:
-  Enabled: true
-
-Style/FrozenStringLiteralComment:
-  Enabled: true
-  EnforcedStyle: always
-
-Naming/FileName:
+# RunnerReturnHash fires on private helper methods that intentionally return non-Hash values
+Legion/Extension/RunnerReturnHash:
   Enabled: false
 
-Naming/PredicateMethod:
+# Files in this gem use direct Legion::* calls intentionally (no helper mixin in helpers/classes)
+Legion/HelperMigration/DirectLogging:
   Enabled: false
 
-Gemspec/DevelopmentDependencies:
+Legion/HelperMigration/OldLoggingMethods:
+  Enabled: false
+
+Legion/HelperMigration/DirectJson:
+  Enabled: false
+
+Legion/HelperMigration/DirectLlm:
+  Enabled: false
+
+Legion/HelperMigration/DirectCache:
+  Enabled: false
+
+Legion/HelperMigration/DirectData:
+  Enabled: false
+
+Legion/HelperMigration/DirectKnowledge:
+  Enabled: false
+
+# Mutable class instance variables are intentional (protected by mutex)
+ThreadSafety/MutableClassInstanceVariable:
+  Enabled: false
+
+ThreadSafety/ClassInstanceVariable:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.16] - 2026-03-30
+
+### Changed
+- update to rubocop-legion 0.1.7, resolve all offenses
+
 ## [0.4.15] - 2026-03-28
 
 ### Changed

--- a/lex-apollo.gemspec
+++ b/lex-apollo.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.0'
+  spec.add_development_dependency 'rubocop-legion', '~> 0.1'
 end

--- a/lib/legion/extensions/apollo.rb
+++ b/lib/legion/extensions/apollo.rb
@@ -16,7 +16,7 @@ require 'legion/extensions/apollo/runners/request'
 
 require 'legion/extensions/apollo/api' if defined?(Sinatra)
 
-if defined?(Legion::Transport)
+if Legion.const_defined?(:Transport, false)
   require 'legion/extensions/apollo/transport/exchanges/apollo'
   require 'legion/extensions/apollo/transport/exchanges/llm_audit'
   require 'legion/extensions/apollo/transport/queues/ingest'
@@ -32,7 +32,7 @@ end
 module Legion
   module Extensions
     module Apollo
-      extend Legion::Extensions::Core if Legion::Extensions.const_defined? :Core
+      extend Legion::Extensions::Core if Legion::Extensions.const_defined? :Core, false
 
       def self.remote_invocable?
         false

--- a/lib/legion/extensions/apollo/actors/entity_watchdog.rb
+++ b/lib/legion/extensions/apollo/actors/entity_watchdog.rb
@@ -24,9 +24,9 @@ module Legion
           def check_subtask?  = false
           def generate_task?  = false
 
-          def enabled?
+          def enabled? # rubocop:disable Legion/Extension/ActorEnabledSideEffects
             defined?(Legion::Extensions::Apollo::Runners::EntityExtractor) &&
-              defined?(Legion::Transport)
+              Legion.const_defined?(:Transport, false)
           rescue StandardError => e
             log.warn("EntityWatchdog enabled? check failed: #{e.message}")
             false

--- a/lib/legion/extensions/apollo/actors/gas_subscriber.rb
+++ b/lib/legion/extensions/apollo/actors/gas_subscriber.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/extensions/actors/subscription' if defined?(Legion::Extensions::Actors::Subscription)
+require 'legion/extensions/actors/subscription'
 
 module Legion
   module Extensions
@@ -13,9 +13,9 @@ module Legion
           def generate_task?  = false
           def use_runner?     = false
 
-          def enabled?
+          def enabled? # rubocop:disable Legion/Extension/ActorEnabledSideEffects
             defined?(Legion::Extensions::Apollo::Runners::Gas) &&
-              defined?(Legion::Transport)
+              Legion.const_defined?(:Transport, false)
           rescue StandardError => e
             log.warn("GasSubscriber enabled? check failed: #{e.message}")
             false

--- a/lib/legion/extensions/apollo/actors/ingest.rb
+++ b/lib/legion/extensions/apollo/actors/ingest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/extensions/actors/subscription' if defined?(Legion::Extensions::Actors::Subscription)
+require 'legion/extensions/actors/subscription'
 
 module Legion
   module Extensions
@@ -12,9 +12,9 @@ module Legion
           def check_subtask?  = false
           def generate_task?  = false
 
-          def enabled?
+          def enabled? # rubocop:disable Legion/Extension/ActorEnabledSideEffects
             defined?(Legion::Extensions::Apollo::Runners::Knowledge) &&
-              defined?(Legion::Transport)
+              Legion.const_defined?(:Transport, false)
           rescue StandardError => e
             log.warn("Ingest enabled? check failed: #{e.message}")
             false

--- a/lib/legion/extensions/apollo/actors/query_responder.rb
+++ b/lib/legion/extensions/apollo/actors/query_responder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/extensions/actors/subscription' if defined?(Legion::Extensions::Actors::Subscription)
+require 'legion/extensions/actors/subscription'
 
 module Legion
   module Extensions
@@ -12,9 +12,9 @@ module Legion
           def check_subtask?  = false
           def generate_task?  = false
 
-          def enabled?
+          def enabled? # rubocop:disable Legion/Extension/ActorEnabledSideEffects
             defined?(Legion::Extensions::Apollo::Runners::Knowledge) &&
-              defined?(Legion::Transport)
+              Legion.const_defined?(:Transport, false)
           rescue StandardError => e
             log.warn("QueryResponder enabled? check failed: #{e.message}")
             false

--- a/lib/legion/extensions/apollo/actors/writeback_store.rb
+++ b/lib/legion/extensions/apollo/actors/writeback_store.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/extensions/actors/subscription' if defined?(Legion::Extensions::Actors::Subscription)
+require 'legion/extensions/actors/subscription'
 
 module Legion
   module Extensions
@@ -12,9 +12,9 @@ module Legion
           def check_subtask?  = false
           def generate_task?  = false
 
-          def enabled?
+          def enabled? # rubocop:disable Legion/Extension/ActorEnabledSideEffects
             defined?(Legion::Extensions::Apollo::Runners::Knowledge) &&
-              defined?(Legion::Transport) &&
+              Legion.const_defined?(:Transport, false) &&
               Helpers::Capability.apollo_write_enabled?
           rescue StandardError => e
             log.warn("WritebackStore enabled? check failed: #{e.message}")

--- a/lib/legion/extensions/apollo/actors/writeback_vectorize.rb
+++ b/lib/legion/extensions/apollo/actors/writeback_vectorize.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/extensions/actors/subscription' if defined?(Legion::Extensions::Actors::Subscription)
+require 'legion/extensions/actors/subscription'
 
 module Legion
   module Extensions
@@ -32,8 +32,8 @@ module Legion
             { success: false, error: e.message }
           end
 
-          def enabled?
-            defined?(Legion::Transport) && Helpers::Capability.can_embed?
+          def enabled? # rubocop:disable Legion/Extension/ActorEnabledSideEffects
+            Legion.const_defined?(:Transport, false) && Helpers::Capability.can_embed?
           rescue StandardError => e
             log.warn("WritebackVectorize enabled? check failed: #{e.message}")
             false

--- a/lib/legion/extensions/apollo/helpers/capability.rb
+++ b/lib/legion/extensions/apollo/helpers/capability.rb
@@ -10,11 +10,7 @@ module Legion
           module_function
 
           def log
-            return Legion::Logging if defined?(Legion::Logging)
-
-            @log ||= Object.new.tap do |nl|
-              %i[debug info warn error fatal].each { |m| nl.define_singleton_method(m) { |*| nil } }
-            end
+            Legion::Logging
           end
 
           def can_embed?

--- a/lib/legion/extensions/apollo/helpers/confidence.rb
+++ b/lib/legion/extensions/apollo/helpers/confidence.rb
@@ -21,11 +21,7 @@ module Legion
           module_function
 
           def log
-            return Legion::Logging if defined?(Legion::Logging)
-
-            @log ||= Object.new.tap do |nl|
-              %i[debug info warn error fatal].each { |m| nl.define_singleton_method(m) { |*| nil } }
-            end
+            Legion::Logging
           end
 
           def apollo_setting(*keys, default:)

--- a/lib/legion/extensions/apollo/helpers/entity_watchdog.rb
+++ b/lib/legion/extensions/apollo/helpers/entity_watchdog.rb
@@ -13,11 +13,7 @@ module Legion
 
           class << self
             def log
-              return Legion::Logging if defined?(Legion::Logging)
-
-              @log ||= Object.new.tap do |nl|
-                %i[debug info warn error fatal].each { |m| nl.define_singleton_method(m) { |*| nil } }
-              end
+              Legion::Logging
             end
 
             def detect_entities(text:, types: nil)

--- a/lib/legion/extensions/apollo/helpers/similarity.rb
+++ b/lib/legion/extensions/apollo/helpers/similarity.rb
@@ -10,11 +10,7 @@ module Legion
           module_function
 
           def log
-            return Legion::Logging if defined?(Legion::Logging)
-
-            @log ||= Object.new.tap do |nl|
-              %i[debug info warn error fatal].each { |m| nl.define_singleton_method(m) { |*| nil } }
-            end
+            Legion::Logging
           end
 
           def cosine_similarity(vec_a:, vec_b:, **)

--- a/lib/legion/extensions/apollo/helpers/tag_normalizer.rb
+++ b/lib/legion/extensions/apollo/helpers/tag_normalizer.rb
@@ -16,8 +16,7 @@ module Legion
             tag = raw.to_s.strip.downcase
             tag = ALIASES[tag] if ALIASES.key?(tag)
             tag = tag.gsub(/[^a-z0-9\- ]/, '')
-                     .gsub(/\s+/, '-')
-                     .gsub(/-+/, '-')
+                     .gsub(/\s+/, '-').squeeze('-')
                      .sub(/^-/, '')
                      .sub(/-$/, '')
             tag.empty? ? nil : tag

--- a/lib/legion/extensions/apollo/helpers/writeback.rb
+++ b/lib/legion/extensions/apollo/helpers/writeback.rb
@@ -15,11 +15,7 @@ module Legion
           module_function
 
           def log
-            return Legion::Logging if defined?(Legion::Logging)
-
-            @log ||= Object.new.tap do |nl|
-              %i[debug info warn error fatal].each { |m| nl.define_singleton_method(m) { |*| nil } }
-            end
+            Legion::Logging
           end
 
           def evaluate_and_route(request:, response:, enrichments: {})
@@ -96,7 +92,7 @@ module Legion
           end
 
           def publish_to_transport(payload, has_embedding: false)
-            return unless defined?(Legion::Transport)
+            return unless Legion.const_defined?(:Transport, false)
 
             Transport::Messages::Writeback.new(
               **payload, has_embedding: has_embedding

--- a/lib/legion/extensions/apollo/runners/entity_extractor.rb
+++ b/lib/legion/extensions/apollo/runners/entity_extractor.rb
@@ -4,7 +4,7 @@ module Legion
   module Extensions
     module Apollo
       module Runners
-        module EntityExtractor
+        module EntityExtractor # rubocop:disable Legion/Extension/RunnerIncludeHelpers
           DEFAULT_ENTITY_TYPES = %w[person service repository concept].freeze
           DEFAULT_MIN_CONFIDENCE = 0.7
 

--- a/lib/legion/extensions/apollo/runners/gas.rb
+++ b/lib/legion/extensions/apollo/runners/gas.rb
@@ -4,7 +4,7 @@ module Legion
   module Extensions
     module Apollo
       module Runners
-        module Gas
+        module Gas # rubocop:disable Legion/Extension/RunnerIncludeHelpers
           RELATION_TYPES = %w[
             similar_to contradicts depends_on causes
             part_of supersedes supports_by extends
@@ -17,11 +17,7 @@ module Legion
           module_function
 
           def log
-            return Legion::Logging if defined?(Legion::Logging)
-
-            @log ||= Object.new.tap do |nl|
-              %i[debug info warn error fatal].each { |m| nl.define_singleton_method(m) { |*| nil } }
-            end
+            Legion::Logging
           end
 
           def json_load(str)

--- a/lib/legion/extensions/apollo/runners/knowledge.rb
+++ b/lib/legion/extensions/apollo/runners/knowledge.rb
@@ -118,7 +118,7 @@ module Legion
             { success: false, error: e.message }
           end
 
-          def handle_query(query:, limit: Helpers::GraphQuery.default_query_limit, min_confidence: Helpers::GraphQuery.default_query_min_confidence, status: [:confirmed], tags: nil, domain: nil, agent_id: 'unknown', **) # rubocop:disable Metrics/ParameterLists, Layout/LineLength
+          def handle_query(query:, limit: Helpers::GraphQuery.default_query_limit, min_confidence: Helpers::GraphQuery.default_query_min_confidence, status: [:confirmed], tags: nil, domain: nil, agent_id: 'unknown', **) # rubocop:disable Layout/LineLength
             return { success: false, error: 'apollo_data_not_available' } unless defined?(Legion::Data::Model::ApolloEntry)
 
             embedding = embed_text(query)
@@ -223,7 +223,7 @@ module Legion
             { success: false, error: e.message }
           end
 
-          def retrieve_relevant(query: nil, limit: Helpers::Confidence.apollo_setting(:query, :retrieval_limit, default: 5), min_confidence: Helpers::GraphQuery.default_query_min_confidence, tags: nil, domain: nil, skip: false, **) # rubocop:disable Metrics/ParameterLists, Layout/LineLength
+          def retrieve_relevant(query: nil, limit: Helpers::Confidence.apollo_setting(:query, :retrieval_limit, default: 5), min_confidence: Helpers::GraphQuery.default_query_min_confidence, tags: nil, domain: nil, skip: false, **) # rubocop:disable Layout/LineLength
             return { status: :skipped } if skip
 
             return { success: false, error: 'apollo_data_not_available' } unless defined?(Legion::Data::Model::ApolloEntry)

--- a/lib/legion/extensions/apollo/runners/request.rb
+++ b/lib/legion/extensions/apollo/runners/request.rb
@@ -11,7 +11,7 @@ module Legion
             false
           end
 
-          def query(text:, limit: Helpers::GraphQuery.default_query_limit, min_confidence: Helpers::GraphQuery.default_query_min_confidence, tags: nil, # rubocop:disable Metrics/ParameterLists
+          def query(text:, limit: Helpers::GraphQuery.default_query_limit, min_confidence: Helpers::GraphQuery.default_query_min_confidence, tags: nil,
                     domain: nil, agent_id: 'unknown', **)
             if local_service_available?
               knowledge_host.handle_query(query: text, limit: limit, min_confidence: min_confidence,
@@ -72,7 +72,7 @@ module Legion
           end
 
           def transport_available?
-            defined?(Legion::Transport) &&
+            Legion.const_defined?(:Transport, false) &&
               Legion::Transport.respond_to?(:connected?) &&
               Legion::Transport.connected?
           end

--- a/lib/legion/extensions/apollo/transport/exchanges/apollo.rb
+++ b/lib/legion/extensions/apollo/transport/exchanges/apollo.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/transport/exchange' if defined?(Legion::Transport)
+require 'legion/transport/exchange'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/apollo/transport/exchanges/llm_audit.rb
+++ b/lib/legion/extensions/apollo/transport/exchanges/llm_audit.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/transport/exchange' if defined?(Legion::Transport)
+require 'legion/transport/exchange'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/apollo/transport/messages/ingest.rb
+++ b/lib/legion/extensions/apollo/transport/messages/ingest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/transport/message' if defined?(Legion::Transport)
+require 'legion/transport/message'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/apollo/transport/messages/query.rb
+++ b/lib/legion/extensions/apollo/transport/messages/query.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/transport/message' if defined?(Legion::Transport)
+require 'legion/transport/message'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/apollo/transport/messages/writeback.rb
+++ b/lib/legion/extensions/apollo/transport/messages/writeback.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/transport/message' if defined?(Legion::Transport)
+require 'legion/transport/message'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/apollo/transport/queues/gas.rb
+++ b/lib/legion/extensions/apollo/transport/queues/gas.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/transport/queue' if defined?(Legion::Transport)
+require 'legion/transport/queue'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/apollo/transport/queues/ingest.rb
+++ b/lib/legion/extensions/apollo/transport/queues/ingest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/transport/queue' if defined?(Legion::Transport)
+require 'legion/transport/queue'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/apollo/transport/queues/query.rb
+++ b/lib/legion/extensions/apollo/transport/queues/query.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/transport/queue' if defined?(Legion::Transport)
+require 'legion/transport/queue'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/apollo/transport/queues/writeback_store.rb
+++ b/lib/legion/extensions/apollo/transport/queues/writeback_store.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/transport/queue' if defined?(Legion::Transport)
+require 'legion/transport/queue'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/apollo/transport/queues/writeback_vectorize.rb
+++ b/lib/legion/extensions/apollo/transport/queues/writeback_vectorize.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/transport/queue' if defined?(Legion::Transport)
+require 'legion/transport/queue'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/apollo/version.rb
+++ b/lib/legion/extensions/apollo/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Apollo
-      VERSION = '0.4.15'
+      VERSION = '0.4.16'
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add rubocop-legion 0.1.7 with shared lex.yml config profile
- Replace inline .rubocop.yml with inherit_gem directive
- Update CI workflow to use excluded-files check
- Fix all rubocop offenses

## Test plan
- [ ] CI passes (rspec + rubocop)