### PR TITLE
fix(handle_ingest): warn-log early-return failure paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+*.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.21] - 2026-04-27
+
+### Changed
+- `Apollo::Runners::Knowledge#handle_ingest` now emits warn-level logs on the three early-return failure paths (nil/blank content, nil content_type, apollo_data_not_available). Companion to PR #15: that PR added `handle_exception` to the rescue paths; this PR closes the silent-failure window for the early-return paths that fire BEFORE any rescue would. Tag values in the log line are sanitized via `gsub(/[\r\n]+/, ' ')` to prevent log-line injection from caller-controlled tags.
+
 ## [0.4.20] - 2026-04-25
 
 ### Fixed

--- a/lib/legion/extensions/apollo/runners/knowledge.rb
+++ b/lib/legion/extensions/apollo/runners/knowledge.rb
@@ -85,9 +85,22 @@ module Legion
 
             content = normalize_text_input(content)
             log.debug("Apollo Knowledge.handle_ingest content_length=#{content.length} content_type=#{content_type} tags=#{Array(tags).size} source_agent=#{source_agent} source_channel=#{source_channel || 'nil'}") # rubocop:disable Layout/LineLength
-            return { success: false, error: 'content is required' } if content.strip.empty?
-            return { success: false, error: 'content_type is required' } if content_type.nil?
-            return { success: false, error: 'apollo_data_not_available' } unless defined?(Legion::Data::Model::ApolloEntry)
+            if content.strip.empty?
+              safe_tags = Array(tags).map(&:to_s).map { |t| t.gsub(/[\r\n]+/, ' ') }
+              log.warn("[apollo][handle_ingest] early-return: content is required " \
+                       "content_type=#{content_type} tags=#{safe_tags.inspect}")
+              return { success: false, error: 'content is required' }
+            end
+            if content_type.nil?
+              log.warn("[apollo][handle_ingest] early-return: content_type is required " \
+                       "content_length=#{content.to_s.length}")
+              return { success: false, error: 'content_type is required' }
+            end
+            unless defined?(Legion::Data::Model::ApolloEntry)
+              log.warn("[apollo][handle_ingest] early-return: apollo_data_not_available " \
+                       "content_type=#{content_type}")
+              return { success: false, error: 'apollo_data_not_available' }
+            end
 
             hash = content_hash || (defined?(Helpers::Writeback) ? Helpers::Writeback.content_hash(content) : nil)
             existing = active_duplicate_for_hash(hash)

--- a/lib/legion/extensions/apollo/runners/knowledge.rb
+++ b/lib/legion/extensions/apollo/runners/knowledge.rb
@@ -85,22 +85,8 @@ module Legion
 
             content = normalize_text_input(content)
             log.debug("Apollo Knowledge.handle_ingest content_length=#{content.length} content_type=#{content_type} tags=#{Array(tags).size} source_agent=#{source_agent} source_channel=#{source_channel || 'nil'}") # rubocop:disable Layout/LineLength
-            if content.strip.empty?
-              safe_tags = Array(tags).map(&:to_s).map { |t| t.gsub(/[\r\n]+/, ' ') }
-              log.warn("[apollo][handle_ingest] early-return: content is required " \
-                       "content_type=#{content_type} tags=#{safe_tags.inspect}")
-              return { success: false, error: 'content is required' }
-            end
-            if content_type.nil?
-              log.warn("[apollo][handle_ingest] early-return: content_type is required " \
-                       "content_length=#{content.to_s.length}")
-              return { success: false, error: 'content_type is required' }
-            end
-            unless defined?(Legion::Data::Model::ApolloEntry)
-              log.warn("[apollo][handle_ingest] early-return: apollo_data_not_available " \
-                       "content_type=#{content_type}")
-              return { success: false, error: 'apollo_data_not_available' }
-            end
+            early_error = ingest_early_return_error(content: content, content_type: content_type, tags: tags)
+            return early_error if early_error
 
             hash = content_hash || (defined?(Helpers::Writeback) ? Helpers::Writeback.content_hash(content) : nil)
             existing = active_duplicate_for_hash(hash)
@@ -365,6 +351,27 @@ module Legion
           CONFLICT_CHECK_MAX_CHARS = 4000
 
           private
+
+          def ingest_early_return_error(content:, content_type:, tags:)
+            if content.strip.empty?
+              safe_tags = Array(tags).map(&:to_s).map { |t| t.gsub(/[\r\n]+/, ' ') }
+              log.warn('[apollo][handle_ingest] early-return: content is required ' \
+                       "content_type=#{content_type} tags=#{safe_tags.inspect}")
+              return { success: false, error: 'content is required' }
+            end
+
+            if content_type.nil?
+              log.warn('[apollo][handle_ingest] early-return: content_type is required ' \
+                       "content_length=#{content.to_s.length}")
+              return { success: false, error: 'content_type is required' }
+            end
+
+            return nil if defined?(Legion::Data::Model::ApolloEntry)
+
+            log.warn('[apollo][handle_ingest] early-return: apollo_data_not_available ' \
+                     "content_type=#{content_type}")
+            { success: false, error: 'apollo_data_not_available' }
+          end
 
           def normalize_content_type(raw)
             sym = raw.to_s.delete_prefix(':').gsub(%r{[/\s]}, '_').strip.downcase.to_sym

--- a/lib/legion/extensions/apollo/version.rb
+++ b/lib/legion/extensions/apollo/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Apollo
-      VERSION = '0.4.20'
+      VERSION = '0.4.21'
     end
   end
 end

--- a/spec/legion/extensions/apollo/runners/knowledge_spec.rb
+++ b/spec/legion/extensions/apollo/runners/knowledge_spec.rb
@@ -337,6 +337,36 @@ RSpec.describe Legion::Extensions::Apollo::Runners::Knowledge do
         )
       end
     end
+
+    context 'early-return warn logs' do
+      let(:logger) { instance_double('Logger', debug: nil, info: nil, warn: nil) }
+
+      before { allow(host).to receive(:log).and_return(logger) }
+
+      it 'emits a warn log when content is nil' do
+        host.handle_ingest(content: nil, content_type: 'fact')
+        expect(logger).to have_received(:warn).with(/early-return: content is required/)
+      end
+
+      it 'emits a warn log when content_type is nil' do
+        host.handle_ingest(content: 'something', content_type: nil)
+        expect(logger).to have_received(:warn).with(/early-return: content_type is required/)
+      end
+
+      it 'emits a warn log when apollo_data_not_available' do
+        hide_const('Legion::Data::Model::ApolloEntry') if defined?(Legion::Data::Model::ApolloEntry)
+        host.handle_ingest(content: 'something', content_type: 'fact')
+        expect(logger).to have_received(:warn).with(/early-return: apollo_data_not_available/)
+      end
+
+      it 'sanitizes newline-bearing tags in the warn log' do
+        host.handle_ingest(content: nil, content_type: 'fact', tags: ["evil\nFAKE LOG LINE", 'normal'])
+        expect(logger).to have_received(:warn) do |msg|
+          expect(msg).to include('evil FAKE LOG LINE')
+          expect(msg).not_to include("\n")
+        end
+      end
+    end
   end
 
   describe '#handle_query' do


### PR DESCRIPTION
# fix(handle_ingest): warn-log early-return failure paths

**Base:** `LegionIO/lex-apollo:main`
**Head:** `armstrongsamr/lex-apollo:fix/handle-ingest-surface-errors`
**Commit:** `4a3f71f`

## Summary

Companion to `LegionIO/lex-apollo#15` (`bug/issues-12-13-14-knowledge-hardening`, merged 2026-04-25). That PR added `handle_exception` to the Sequel rescue paths in `Runners::Knowledge`, but the three early-return failure paths in `handle_ingest` still return `{success: false, error: ...}` silently. They fire **before** any rescue could, so a malformed call leaves no log line for diagnosis. This PR closes that window with warn-level logs on each early-return.

## Why

`handle_ingest` is the primary write path for the Apollo knowledge store. Three of its four failure modes (nil/blank `content`, nil `content_type`, missing `Legion::Data::Model::ApolloEntry`) sit above the rescue and are reached on validation errors before a Sequel query is even attempted. PR #15 closed the rescue-path silence; the early-return silence remained, which means every shape of "caller sent a bad request" still appears as a clean HTTP failure with zero diagnostic breadcrumbs in `legion.log`. Pairing this with #15 produces full coverage: every `{success: false}` path emits something an on-call responder can grep.

## Changes

`lib/legion/extensions/apollo/runners/knowledge.rb` — `handle_ingest` early-returns only:

1. **Three early-return branches now warn-log before returning** with the `[apollo][handle_ingest] early-return: <reason>` prefix and per-branch context (`content_type`, sanitized `tags`, `content_length`).
2. **`safe_tags` sanitization** — tags are caller-controlled (they originate at the ingest API surface). Before interpolation into the `content is required` log line they pass through `Array(tags).map(&:to_s).map { |t| t.gsub(/[\r\n]+/, ' ') }`, preventing log-line injection from an embedded `\n`/`\r` in a tag value.
3. **CHANGELOG entry under `[0.4.21]` → `Changed:`** and version bump `0.4.20` → `0.4.21`.

No rescue logic is touched (PR #15 already calls `handle_exception` there). No new exception classes are caught (preserves PR #15's narrower scope).

## Before / After

**Before** (post-#15 upstream `main`, lines 88-90):

```ruby
return { success: false, error: 'content is required' } if content.strip.empty?
return { success: false, error: 'content_type is required' } if content_type.nil?
return { success: false, error: 'apollo_data_not_available' } unless defined?(Legion::Data::Model::ApolloEntry)
```

**After**:

```ruby
if content.strip.empty?
  safe_tags = Array(tags).map(&:to_s).map { |t| t.gsub(/[\r\n]+/, ' ') }
  log.warn("[apollo][handle_ingest] early-return: content is required " \
           "content_type=#{content_type} tags=#{safe_tags.inspect}")
  return { success: false, error: 'content is required' }
end
if content_type.nil?
  log.warn("[apollo][handle_ingest] early-return: content_type is required " \
           "content_length=#{content.to_s.length}")
  return { success: false, error: 'content_type is required' }
end
unless defined?(Legion::Data::Model::ApolloEntry)
  log.warn("[apollo][handle_ingest] early-return: apollo_data_not_available " \
           "content_type=#{content_type}")
  return { success: false, error: 'apollo_data_not_available' }
end
```

The main body (dedup, `embed_text`, `ApolloEntry.create`, contradictions) and the `rescue Sequel::Error` tail are bit-identical to upstream `main`.

## Tests

New `early-return warn logs` context in `spec/legion/extensions/apollo/runners/knowledge_spec.rb` under `#handle_ingest` (4 specs):

- `emits a warn log when content is nil`
- `emits a warn log when content_type is nil`
- `emits a warn log when apollo_data_not_available`
- `sanitizes newline-bearing tags in the warn log` — calls with `tags: ["evil\nFAKE LOG LINE", "normal"]`, asserts the message contains `evil FAKE LOG LINE` (single-line, newline-collapsed) and not a literal `\n`

## Version

`0.4.20` → `0.4.21`. CHANGELOG entry under `[0.4.21]` → `Changed:`:

> - `Apollo::Runners::Knowledge#handle_ingest` now emits warn-level logs on the three early-return failure paths (nil/blank content, nil content_type, apollo_data_not_available). Companion to PR #15: that PR added `handle_exception` to the rescue paths; this PR closes the silent-failure window for the early-return paths that fire BEFORE any rescue would. Tag values in the log line are sanitized via `gsub(/[\r\n]+/, ' ')` to prevent log-line injection from caller-controlled tags.

## Live validation

The same patch shape has been live in the local Cellar copy (`lib/legion/extensions/apollo/runners/knowledge.rb`) for several days. The same fingerprint round-trip that proved the lex-knowledge `content_hash` PR also exercises this path — when the upstream caller supplies a malformed payload, the early-return warns now appear in `legion.log`, where previously the daemon was silent.

## Related

- `LegionIO/lex-apollo#15` — `bug/issues-12-13-14-knowledge-hardening` (merged 2026-04-25). Added `handle_exception` to `Runners::Knowledge` rescue paths. This PR is the companion that covers the early-return paths #15 left unaddressed.

## Future work (out of scope)

The same silent-early-return shape exists in six sibling methods in the same file:

- `handle_query`
- `handle_traverse`
- `retrieve_relevant`
- `redistribute_knowledge`
- `prepare_mesh_export`
- `handle_erasure_request`

Applying the same pattern there is a mechanical follow-up. Filed separately to keep this PR's review surface tight.

## Checklist

- [x] Tests pass (`bundle exec rspec`)
- [x] RuboCop passes (`bundle exec rubocop`)
- [x] CHANGELOG.md updated (`[0.4.21]` → `Changed:` entry shown in **Version** section)
- [x] No new security concerns introduced — log-line injection via tag values is mitigated by `safe_tags` sanitization (`gsub(/[\r\n]+/, ' ')`) before any interpolation.
