### PR TITLE
fix(api): populate Apollo stats health metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Gemfile.lock
 *.gem
+.rspec_status
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.22] - 2026-04-28
+
+### Fixed
+- `/api/apollo/stats` now returns the health UI metrics Interlink expects: `recent_24h`, `avg_confidence`, and a synthesized `by_status["active"]` count for non-archived entries. This keeps the Knowledge Health cards populated instead of rendering missing values. Fixes #16.
+
 ## [0.4.21] - 2026-04-27
 
 ### Changed

--- a/lib/legion/extensions/apollo/api.rb
+++ b/lib/legion/extensions/apollo/api.rb
@@ -9,6 +9,37 @@ module Legion
       class Api < Sinatra::Base
         set :host_authorization, permitted: :any
 
+        class << self
+          def stats_payload(now: Time.now)
+            return { error: 'apollo_data_not_available' } unless defined?(Legion::Data::Model::ApolloEntry)
+
+            entries = Legion::Data::Model::ApolloEntry
+            by_status = grouped_counts(entries, :status)
+            by_status['active'] = entries.exclude(status: 'archived').count
+
+            stats = {
+              total_entries:   entries.count,
+              recent_24h:      entries.where { created_at >= (now - 86_400) }.count,
+              avg_confidence:  average_confidence(entries),
+              by_status:       by_status,
+              by_content_type: grouped_counts(entries, :content_type)
+            }
+            stats[:total_relations] = Legion::Data::Model::ApolloRelation.count if defined?(Legion::Data::Model::ApolloRelation)
+            stats
+          end
+
+          private
+
+          def grouped_counts(entries, column)
+            entries.group_and_count(column).all.to_h { |row| [row[column].to_s, row[:count]] }
+          end
+
+          def average_confidence(entries)
+            avg = entries.avg(:confidence)
+            avg&.to_f&.round(3)
+          end
+        end
+
         before do
           content_type :json
         end
@@ -140,18 +171,7 @@ module Legion
 
         # Statistics
         get '/api/apollo/stats' do
-          stats = {}
-          if defined?(Legion::Data::Model::ApolloEntry)
-            stats[:total_entries] = Legion::Data::Model::ApolloEntry.count
-            stats[:by_status]     = Legion::Data::Model::ApolloEntry.group_and_count(:status).all
-                                                                    .to_h { |r| [r[:status], r[:count]] }
-            stats[:by_content_type] = Legion::Data::Model::ApolloEntry.group_and_count(:content_type).all
-                                                                      .to_h { |r| [r[:content_type], r[:count]] }
-            stats[:total_relations] = Legion::Data::Model::ApolloRelation.count if defined?(Legion::Data::Model::ApolloRelation)
-          else
-            stats[:error] = 'apollo_data_not_available'
-          end
-          stats.to_json
+          self.class.stats_payload.to_json
         end
       end
     end

--- a/lib/legion/extensions/apollo/version.rb
+++ b/lib/legion/extensions/apollo/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Apollo
-      VERSION = '0.4.21'
+      VERSION = '0.4.22'
     end
   end
 end

--- a/spec/legion/extensions/apollo/api_spec.rb
+++ b/spec/legion/extensions/apollo/api_spec.rb
@@ -25,4 +25,68 @@ RSpec.describe Legion::Extensions::Apollo::Api do
   it 'is defined as a Sinatra app' do
     expect(described_class.superclass).to eq(Sinatra::Base)
   end
+
+  describe '.stats_payload' do
+    let(:entry_model) { class_double('Legion::Data::Model::ApolloEntry') }
+    let(:relation_model) { class_double('Legion::Data::Model::ApolloRelation', count: 4) }
+    let(:status_counts) do
+      instance_double(
+        'StatusCounts',
+        all: [
+          { status: 'candidate', count: 2 },
+          { status: 'confirmed', count: 3 },
+          { status: 'archived', count: 1 }
+        ]
+      )
+    end
+    let(:content_type_counts) do
+      instance_double(
+        'ContentTypeCounts',
+        all: [
+          { content_type: 'document_chunk', count: 5 },
+          { content_type: 'observation', count: 1 }
+        ]
+      )
+    end
+    let(:active_entries) { instance_double('ActiveEntries', count: 5) }
+    let(:recent_entries) { instance_double('RecentEntries', count: 2) }
+
+    before do
+      stub_const('Legion::Data::Model::ApolloEntry', entry_model)
+      stub_const('Legion::Data::Model::ApolloRelation', relation_model)
+      allow(entry_model).to receive(:count).and_return(6)
+      allow(entry_model).to receive(:avg).with(:confidence).and_return(0.81234)
+      allow(entry_model).to receive(:exclude).with(status: 'archived').and_return(active_entries)
+      allow(entry_model).to receive(:where).and_return(recent_entries)
+      allow(entry_model).to receive(:group_and_count).with(:status).and_return(status_counts)
+      allow(entry_model).to receive(:group_and_count).with(:content_type).and_return(content_type_counts)
+    end
+
+    it 'returns the health UI metrics expected by Interlink' do
+      payload = described_class.stats_payload(now: Time.utc(2026, 4, 28, 12, 0, 0))
+
+      expect(payload).to include(
+        total_entries:   6,
+        recent_24h:      2,
+        avg_confidence:  0.812,
+        total_relations: 4
+      )
+      expect(payload[:by_status]).to include(
+        'candidate' => 2,
+        'confirmed' => 3,
+        'archived'  => 1,
+        'active'    => 5
+      )
+      expect(payload[:by_content_type]).to eq(
+        'document_chunk' => 5,
+        'observation'    => 1
+      )
+    end
+
+    it 'returns an apollo data error when the entry model is unavailable' do
+      hide_const('Legion::Data::Model::ApolloEntry')
+
+      expect(described_class.stats_payload).to eq(error: 'apollo_data_not_available')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- warn-log `handle_ingest` early-return failure paths so silent Apollo ingest failures are visible
- populate `/api/apollo/stats` with the Interlink Health UI metrics: `recent_24h`, `avg_confidence`, and synthesized `by_status["active"]`
- bump `lex-apollo` to `0.4.22` with separate changelog entries for `0.4.21` and `0.4.22`
- ignore local verification artifacts (`.rspec_status`, `tmp/`) alongside existing gem artifacts

Fixes #16

## Validation

- `bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt`
- `bundle exec rubocop -A`
