### PR TITLE
Fix entity watchdog duplicate extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.25] - 2026-05-08
+
+### Fixed
+- Entity watchdog now remembers processed task-log text during the process lifetime so unchanged logs do not trigger repeated structured LLM extraction on every watchdog interval.
+
 ## [0.4.24] - 2026-05-07
 
 ### Fixed

--- a/lib/legion/extensions/apollo/actors/entity_watchdog.rb
+++ b/lib/legion/extensions/apollo/actors/entity_watchdog.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'digest'
 require 'legion/extensions/actors/every'
 require_relative '../runners/knowledge'
 require_relative '../runners/entity_extractor'
@@ -40,6 +41,8 @@ module Legion
 
             ingested = 0
             texts.each do |text|
+              next if task_log_text_processed?(text)
+
               result = extract_entities(
                 text:           text,
                 entity_types:   entity_types,
@@ -47,6 +50,7 @@ module Legion
               )
               next unless result[:success]
 
+              mark_task_log_text_processed(text) unless result[:source] == :unavailable
               result[:entities].each do |entity|
                 next if entity_exists_in_apollo?(entity)
 
@@ -123,6 +127,28 @@ module Legion
 
           def dedup_similarity_threshold
             settings[:entity_watchdog][:dedup_threshold].to_f
+          end
+
+          def task_log_text_processed?(text)
+            processed_task_log_hashes.key?(task_log_text_hash(text))
+          end
+
+          def mark_task_log_text_processed(text)
+            hashes = processed_task_log_hashes
+            hashes[task_log_text_hash(text)] = true
+            hashes.shift while hashes.size > processed_task_log_hash_limit
+          end
+
+          def processed_task_log_hashes
+            @processed_task_log_hashes ||= {}
+          end
+
+          def processed_task_log_hash_limit
+            [settings[:entity_watchdog][:log_limit].to_i * 4, 100].max
+          end
+
+          def task_log_text_hash(text)
+            Digest::SHA256.hexdigest(text.to_s)
           end
         end
       end

--- a/lib/legion/extensions/apollo/version.rb
+++ b/lib/legion/extensions/apollo/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Apollo
-      VERSION = '0.4.24'
+      VERSION = '0.4.25'
     end
   end
 end

--- a/spec/legion/extensions/apollo/actors/entity_watchdog_spec.rb
+++ b/spec/legion/extensions/apollo/actors/entity_watchdog_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe Legion::Extensions::Apollo::Actor::EntityWatchdog do
       expect(actor).to have_received(:publish_entity_ingest).once
     end
 
+    it 'does not extract entities from the same task log text twice' do
+      actor.scan_and_ingest
+      actor.scan_and_ingest
+
+      expect(actor).to have_received(:extract_entities).once
+    end
+
     context 'when entity already exists in Apollo (high similarity)' do
       let(:existing_match) do
         { success: true, entries: [{ id: 42, content: 'lex-synapse', distance: 0.02 }], count: 1 }


### PR DESCRIPTION
Summary
- Cache processed task-log text hashes to avoid repeated structured LLM extraction.
- Add regression spec plus release metadata.

Validation
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A