### PR TITLE
feat(lex-apollo): identity persistence, access_scope enforcement (global/team/private), erasure compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.4.27] - 2026-05-15
+
+### Added
+- `handle_ingest` now accepts and persists `access_scope`, `identity_principal_id`, `identity_id`, and `identity_canonical_name` to `apollo_entries`. These kwargs are injected automatically by `legion-apollo`'s identity middleware; no callers need updating. Defaults to `access_scope: 'global'` for backward compatibility.
+- `build_semantic_search_sql` accepts an optional `requesting_principal_id:` kwarg and adds an access-scope SQL filter when provided: `global` entries are always visible, `team` entries are visible when the requesting principal shares a group membership with the submitter, and `private` entries are visible only to the owning principal (checked via both `identity_principal_id` FK and an `identities` subquery for multi-provider auth).
+- `handle_query` and `retrieve_relevant` both accept and forward `requesting_principal_id:` to the SQL builder — covers the GAIA path (`handle_query`) and the direct-call path (`retrieve_relevant`).
+- Browse-mode fallback in `handle_query` (`list_entries_chronologically`) also applies the same access-scope filter when `requesting_principal_id:` is provided.
+- Private-entry dedup guard in `active_duplicate_for_hash`: when `access_scope: 'private'` and `identity_principal_id` is set, the dedup query is scoped per-principal so two different principals writing identical content each get their own row.
+
+### Fixed
+- `handle_erasure_request` now clears `identity_principal_id`, `identity_id`, and `identity_canonical_name` on confirmed (redacted) entries in addition to the existing `source_agent`/`source_provider`/`source_channel` redaction — GDPR right-to-erasure compliance gap.
+
 ## [0.4.26] - 2026-05-11
 
 ### Fixed

--- a/lib/legion/extensions/apollo/helpers/graph_query.rb
+++ b/lib/legion/extensions/apollo/helpers/graph_query.rb
@@ -52,7 +52,9 @@ module Legion
             SQL
           end
 
-          def build_semantic_search_sql(limit: default_query_limit, min_confidence: default_query_min_confidence, statuses: nil, tags: nil, domain: nil, **)
+          def build_semantic_search_sql(limit: default_query_limit, min_confidence: default_query_min_confidence,
+                                        statuses: nil, tags: nil, domain: nil,
+                                        requesting_principal_id: nil, **)
             conditions = ["e.confidence >= #{min_confidence}"]
 
             if statuses&.any?
@@ -66,6 +68,23 @@ module Legion
             end
 
             conditions << "e.knowledge_domain = '#{domain}'" if domain
+
+            if requesting_principal_id
+              pid = requesting_principal_id.to_i
+              conditions << <<~SCOPE_SQL.strip
+                (e.access_scope = 'global'
+                 OR (e.access_scope = 'private'
+                     AND (e.identity_principal_id = #{pid}
+                          OR e.identity_id IN (SELECT id FROM identities WHERE principal_id = #{pid})))
+                 OR (e.access_scope = 'team'
+                     AND EXISTS (
+                       SELECT 1 FROM identity_group_memberships igm1
+                       JOIN identity_group_memberships igm2 ON igm1.group_id = igm2.group_id
+                       WHERE igm1.principal_id = #{pid}
+                         AND igm2.principal_id = e.identity_principal_id
+                     )))
+              SCOPE_SQL
+            end
 
             where_clause = conditions.join(' AND ')
 

--- a/lib/legion/extensions/apollo/runners/knowledge.rb
+++ b/lib/legion/extensions/apollo/runners/knowledge.rb
@@ -82,7 +82,11 @@ module Legion
             }
           end
 
-          def handle_ingest(content: nil, content_type: nil, tags: [], source_agent: 'unknown', source_provider: nil, source_channel: nil, knowledge_domain: nil, submitted_by: nil, submitted_from: nil, content_hash: nil, context: {}, skip: false, **) # rubocop:disable Metrics/ParameterLists, Layout/LineLength
+          def handle_ingest(content: nil, content_type: nil, tags: [], source_agent: 'unknown', # rubocop:disable Metrics/ParameterLists
+                            source_provider: nil, source_channel: nil, knowledge_domain: nil,
+                            submitted_by: nil, submitted_from: nil, content_hash: nil, context: {},
+                            skip: false, access_scope: 'global', identity_principal_id: nil,
+                            identity_id: nil, identity_canonical_name: nil, **)
             return { status: :skipped } if skip
 
             content = normalize_text_input(content)
@@ -92,7 +96,8 @@ module Legion
             return early_error if early_error
 
             hash = content_hash || (defined?(Helpers::Writeback) ? Helpers::Writeback.content_hash(content) : nil)
-            existing = active_duplicate_for_hash(hash)
+            existing = active_duplicate_for_hash(hash, access_scope:          access_scope,
+                                                       identity_principal_id: identity_principal_id)
             if existing
               log.info("Apollo Knowledge.handle_ingest deduped entry_id=#{existing.id} source_agent=#{source_agent}")
               return { success: true, entry_id: existing.id, deduped: true }
@@ -102,7 +107,11 @@ module Legion
             content_type_sym = content_type.to_s
             metadata = ingest_metadata(tags: tags, knowledge_domain: knowledge_domain, source_agent: source_agent,
                                        source_provider: source_provider, source_channel: source_channel,
-                                       submitted_by: submitted_by, submitted_from: submitted_from)
+                                       submitted_by: submitted_by, submitted_from: submitted_from,
+                                       access_scope: access_scope,
+                                       identity_principal_id: identity_principal_id,
+                                       identity_id: identity_id,
+                                       identity_canonical_name: identity_canonical_name)
 
             corroborated, existing_id = find_corroboration(
               embedding, content_type_sym, metadata[:source_agent], metadata[:source_channel]
@@ -425,49 +434,62 @@ module Legion
             normalize_text_input(value)[0, max_length]
           end
 
-          def active_duplicate_for_hash(hash)
+          def active_duplicate_for_hash(hash, access_scope: nil, identity_principal_id: nil)
             return nil unless hash
 
-            existing = Helpers::DataModels.apollo_entry
-                                          .where(content_hash: hash)
-                                          .exclude(status: 'archived')
-                                          .first
+            dataset = Helpers::DataModels.apollo_entry
+                                         .where(content_hash: hash)
+                                         .exclude(status: 'archived')
+
+            dataset = dataset.where(identity_principal_id: identity_principal_id) if access_scope == 'private' && identity_principal_id
+
+            existing = dataset.first
             existing&.update(confidence: [existing.confidence + Helpers::Confidence.retrieval_boost, 1.0].min)
             log.debug("Apollo Knowledge.active_duplicate_for_hash matched entry_id=#{existing.id}") if existing
             existing
           end
 
-          def ingest_metadata(tags:, knowledge_domain:, source_agent:, source_provider:, source_channel:, submitted_by:, submitted_from:)
+          def ingest_metadata(tags:, knowledge_domain:, source_agent:, source_provider:, source_channel:, # rubocop:disable Metrics/ParameterLists
+                              submitted_by:, submitted_from:, access_scope: 'global',
+                              identity_principal_id: nil, identity_id: nil, identity_canonical_name: nil)
             tag_array = defined?(Helpers::TagNormalizer) ? Helpers::TagNormalizer.normalize_all(tags) : Array(tags)
             agent = truncate_for_column(source_agent, 50) || 'unknown'
 
-            { tags:            tag_array,
-              domain:          truncate_for_column(knowledge_domain || tag_array.first || 'general', 50),
-              source_agent:    agent,
-              source_provider: truncate_for_column(source_provider || derive_provider_from_agent(agent), 50),
-              source_channel:  truncate_for_column(source_channel, 100),
-              submitted_by:    truncate_for_column(submitted_by, 255),
-              submitted_from:  truncate_for_column(submitted_from, 255) }
+            { tags:                    tag_array,
+              domain:                  truncate_for_column(knowledge_domain || tag_array.first || 'general', 50),
+              source_agent:            agent,
+              source_provider:         truncate_for_column(source_provider || derive_provider_from_agent(agent), 50),
+              source_channel:          truncate_for_column(source_channel, 100),
+              submitted_by:            truncate_for_column(submitted_by, 255),
+              submitted_from:          truncate_for_column(submitted_from, 255),
+              access_scope:            access_scope || 'global',
+              identity_principal_id:   identity_principal_id.is_a?(Integer) ? identity_principal_id : nil,
+              identity_id:             identity_id.is_a?(Integer) ? identity_id : nil,
+              identity_canonical_name: identity_canonical_name&.to_s&.slice(0, 255) }
           end
 
           def create_candidate_entry(content:, content_type:, context:, metadata:, content_hash:, embedding:)
             new_entry = Helpers::DataModels.apollo_entry.create(
-              content:          content,
-              content_type:     content_type,
-              confidence:       Helpers::Confidence.initial_confidence,
-              source_agent:     metadata[:source_agent],
-              source_provider:  metadata[:source_provider],
-              source_channel:   metadata[:source_channel],
-              source_context:   json_dump(context.is_a?(Hash) ? context : {}),
-              tags:             Sequel.pg_array(metadata[:tags]),
-              status:           'candidate',
-              knowledge_domain: metadata[:domain],
-              submitted_by:     metadata[:submitted_by],
-              submitted_from:   metadata[:submitted_from],
-              content_hash:     content_hash,
-              embedding:        embedding ? Sequel.lit("'[#{embedding.join(',')}]'::vector") : nil
+              content:                 content,
+              content_type:            content_type,
+              confidence:              Helpers::Confidence.initial_confidence,
+              source_agent:            metadata[:source_agent],
+              source_provider:         metadata[:source_provider],
+              source_channel:          metadata[:source_channel],
+              source_context:          json_dump(context.is_a?(Hash) ? context : {}),
+              tags:                    Sequel.pg_array(metadata[:tags]),
+              status:                  'candidate',
+              knowledge_domain:        metadata[:domain],
+              submitted_by:            metadata[:submitted_by],
+              submitted_from:          metadata[:submitted_from],
+              content_hash:            content_hash,
+              access_scope:            metadata[:access_scope] || 'global',
+              identity_principal_id:   metadata[:identity_principal_id],
+              identity_id:             metadata[:identity_id],
+              identity_canonical_name: metadata[:identity_canonical_name],
+              embedding:               embedding ? Sequel.lit("'[#{embedding.join(',')}]'::vector") : nil
             )
-            log.info("Apollo Knowledge.handle_ingest created entry_id=#{new_entry.id} status=candidate domain=#{metadata[:domain]} source_agent=#{metadata[:source_agent]}") # rubocop:disable Layout/LineLength
+            log.info("Apollo Knowledge.handle_ingest created entry_id=#{new_entry.id} status=candidate domain=#{metadata[:domain]} source_agent=#{metadata[:source_agent]} access_scope=#{metadata[:access_scope]}") # rubocop:disable Layout/LineLength
             new_entry.id
           rescue Sequel::UniqueConstraintViolation => e
             # Race condition: another thread/process inserted the same content_hash between our

--- a/lib/legion/extensions/apollo/runners/knowledge.rb
+++ b/lib/legion/extensions/apollo/runners/knowledge.rb
@@ -359,10 +359,16 @@ module Legion
                       .exclude(status: 'confirmed')
                       .delete
 
-            # Redact attribution on confirmed entries (corroborated, retain knowledge)
             redacted = conn[:apollo_entries]
                        .where(source_agent: agent_id, status: 'confirmed')
-                       .update(source_agent: 'redacted', source_provider: nil, source_channel: nil)
+                       .update(
+                         source_agent:            'redacted',
+                         source_provider:         nil,
+                         source_channel:          nil,
+                         identity_principal_id:   nil,
+                         identity_id:             nil,
+                         identity_canonical_name: nil
+                       )
 
             { deleted: deleted, redacted: redacted, agent_id: agent_id }
               .tap { |result| log.info("Apollo Knowledge.handle_erasure_request deleted=#{result[:deleted]} redacted=#{result[:redacted]} agent_id=#{agent_id}") } # rubocop:disable Layout/LineLength

--- a/lib/legion/extensions/apollo/runners/knowledge.rb
+++ b/lib/legion/extensions/apollo/runners/knowledge.rb
@@ -142,7 +142,10 @@ module Legion
             { success: false, error: e.message }
           end
 
-          def handle_query(query:, limit: Helpers::GraphQuery.default_query_limit, min_confidence: Helpers::GraphQuery.default_query_min_confidence, status: UNSET, tags: nil, domain: nil, agent_id: 'unknown', **) # rubocop:disable Layout/LineLength, Metrics/CyclomaticComplexity
+          def handle_query(query:, limit: Helpers::GraphQuery.default_query_limit, # rubocop:disable Metrics/CyclomaticComplexity, Metrics/ParameterLists
+                           min_confidence: Helpers::GraphQuery.default_query_min_confidence,
+                           status: UNSET, tags: nil, domain: nil, agent_id: 'unknown',
+                           requesting_principal_id: nil, **)
             return { success: false, error: 'apollo_data_not_available' } unless Helpers::DataModels.apollo_entry_available?
 
             entry_model = Helpers::DataModels.apollo_entry
@@ -152,19 +155,22 @@ module Legion
             log.debug("Apollo Knowledge.handle_query mode=#{browse_query?(query) ? 'browse' : 'semantic'} query_length=#{query.length} limit=#{limit} statuses=#{Array(requested_status).join(',')} status_defaulted=#{status_defaulted} tags=#{Array(tags).size} domain=#{domain || 'nil'} agent_id=#{agent_id}") # rubocop:disable Layout/LineLength
             if browse_query?(query)
               return list_entries_chronologically(query: query, limit: limit, status: requested_status,
-                                                  status_defaulted: status_defaulted, tags: tags, domain: domain)
+                                                  status_defaulted: status_defaulted, tags: tags, domain: domain,
+                                                  requesting_principal_id: requesting_principal_id)
             end
 
             embedding = embed_text(query)
             if embedding.nil?
               log.warn('Apollo Knowledge.handle_query embedding unavailable; falling back to browse query')
               return list_entries_chronologically(query: query, limit: limit, status: requested_status,
-                                                  status_defaulted: status_defaulted, tags: tags, domain: domain)
+                                                  status_defaulted: status_defaulted, tags: tags, domain: domain,
+                                                  requesting_principal_id: requesting_principal_id)
             end
 
             sql = Helpers::GraphQuery.build_semantic_search_sql(
               limit: limit, min_confidence: min_confidence,
-              statuses: Array(requested_status).map(&:to_s), tags: tags, domain: domain
+              statuses: Array(requested_status).map(&:to_s), tags: tags, domain: domain,
+              requesting_principal_id: requesting_principal_id
             )
 
             db = entry_model.db
@@ -260,7 +266,9 @@ module Legion
             { success: false, error: e.message }
           end
 
-          def retrieve_relevant(query: nil, limit: Helpers::Confidence.apollo_setting(:query, :retrieval_limit, default: 5), min_confidence: Helpers::GraphQuery.default_query_min_confidence, tags: nil, domain: nil, skip: false, **) # rubocop:disable Layout/LineLength
+          def retrieve_relevant(query: nil, limit: Helpers::Confidence.apollo_setting(:query, :retrieval_limit, default: 5),
+                                min_confidence: Helpers::GraphQuery.default_query_min_confidence,
+                                tags: nil, domain: nil, skip: false, requesting_principal_id: nil, **)
             return { status: :skipped } if skip
 
             return { success: false, error: 'apollo_data_not_available' } unless Helpers::DataModels.apollo_entry_available?
@@ -277,7 +285,8 @@ module Legion
 
             sql = Helpers::GraphQuery.build_semantic_search_sql(
               limit: limit, min_confidence: min_confidence,
-              statuses: %w[confirmed candidate], tags: tags, domain: domain
+              statuses: %w[confirmed candidate], tags: tags, domain: domain,
+              requesting_principal_id: requesting_principal_id
             )
 
             db = Helpers::DataModels.apollo_entry.db
@@ -513,13 +522,25 @@ module Legion
             query.to_s.strip.length < 3
           end
 
-          def list_entries_chronologically(query:, limit:, status:, status_defaulted:, tags:, domain:)
+          def list_entries_chronologically(query:, limit:, status:, status_defaulted:, tags:, domain:, requesting_principal_id: nil)
             log.debug("Apollo Knowledge.list_entries_chronologically limit=#{limit} statuses=#{Array(status).join(',')} status_defaulted=#{status_defaulted} tags=#{Array(tags).size} domain=#{domain || 'nil'}") # rubocop:disable Layout/LineLength
             dataset = Helpers::DataModels.apollo_entry.exclude(status: 'archived')
             requested = Array(status).map(&:to_s).reject(&:empty?)
             dataset = dataset.where(status: requested) unless status_defaulted || requested.empty?
             dataset = dataset.where(Sequel.lit('tags && ?', Sequel.pg_array(Array(tags)))) if tags && !Array(tags).empty?
             dataset = dataset.where(knowledge_domain: domain) if domain && !domain.to_s.empty?
+
+            if requesting_principal_id
+              pid = requesting_principal_id.to_i
+              dataset = dataset.where(
+                Sequel.lit(
+                  "(access_scope = 'global' " \
+                  "OR (access_scope = 'private' AND (identity_principal_id = ? OR identity_id IN (SELECT id FROM identities WHERE principal_id = ?))) " \
+                  "OR (access_scope = 'team' AND EXISTS (SELECT 1 FROM identity_group_memberships igm1 JOIN identity_group_memberships igm2 ON igm1.group_id = igm2.group_id WHERE igm1.principal_id = ? AND igm2.principal_id = identity_principal_id)))", # rubocop:disable Layout/LineLength
+                  pid, pid, pid
+                )
+              )
+            end
 
             entries = dataset.order(Sequel.desc(:created_at)).limit(limit).all.map do |entry|
               format_entry(entry.is_a?(Hash) ? entry : entry.values)

--- a/lib/legion/extensions/apollo/version.rb
+++ b/lib/legion/extensions/apollo/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Apollo
-      VERSION = '0.4.26'
+      VERSION = '0.4.27'
     end
   end
 end

--- a/spec/legion/extensions/apollo/helpers/graph_query_spec.rb
+++ b/spec/legion/extensions/apollo/helpers/graph_query_spec.rb
@@ -65,5 +65,36 @@ RSpec.describe Legion::Extensions::Apollo::Helpers::GraphQuery do
       expect(sql).to include("'dns'")
       expect(sql).to include('&&')
     end
+
+    context 'without requesting_principal_id' do
+      it 'includes no access_scope filter' do
+        sql = described_class.build_semantic_search_sql(limit: 5, min_confidence: 0.3)
+        expect(sql).not_to include('access_scope')
+      end
+    end
+
+    context 'with requesting_principal_id' do
+      let(:sql) { described_class.build_semantic_search_sql(limit: 5, min_confidence: 0.3, requesting_principal_id: 42) }
+
+      it 'allows global entries unconditionally' do
+        expect(sql).to include("access_scope = 'global'")
+      end
+
+      it 'allows private entries owned by the principal via principal FK' do
+        expect(sql).to include('e.identity_principal_id = 42')
+      end
+
+      it 'allows private entries owned by the principal via identity subquery (multi-provider auth)' do
+        expect(sql).to include('SELECT id FROM identities WHERE principal_id = 42')
+      end
+
+      it 'allows team entries when principal shares a group with the submitter' do
+        expect(sql).to include('identity_group_memberships')
+      end
+
+      it 'wraps the entire access_scope condition in parentheses so it does not break AND chaining' do
+        expect(sql).to match(/AND \(.*access_scope.*\)/m)
+      end
+    end
   end
 end

--- a/spec/legion/extensions/apollo/runners/knowledge_spec.rb
+++ b/spec/legion/extensions/apollo/runners/knowledge_spec.rb
@@ -371,6 +371,95 @@ RSpec.describe Legion::Extensions::Apollo::Runners::Knowledge do
       end
     end
 
+    context 'identity kwargs persistence' do
+      let(:mock_entry_class2) { double('ApolloEntry2') }
+      let(:mock_expertise_class2) { double('ApolloExpertise2') }
+      let(:mock_access_log_class2) { double('ApolloAccessLog2') }
+      let(:mock_entry2) { double('entry2', id: 99, embedding: nil) }
+
+      before do
+        stub_const('Legion::Data::Model::ApolloEntry', mock_entry_class2)
+        stub_const('Legion::Data::Model::ApolloExpertise', mock_expertise_class2)
+        stub_const('Legion::Data::Model::ApolloAccessLog', mock_access_log_class2)
+        scoped_ds = double('scoped_ds2', first: nil, where: double('scoped_ds2b', first: nil))
+        allow(mock_entry_class2).to receive(:where).and_return(scoped_ds)
+        allow(scoped_ds).to receive(:exclude).and_return(scoped_ds)
+        allow(mock_expertise_class2).to receive(:where).and_return(double(first: nil))
+        allow(mock_expertise_class2).to receive(:create)
+        allow(mock_access_log_class2).to receive(:create)
+        allow(host).to receive(:embed_text).and_return(nil)
+        allow(host).to receive(:find_corroboration).and_return([false, nil])
+        allow(host).to receive(:detect_contradictions).and_return([])
+      end
+
+      it 'passes identity_principal_id and access_scope through to create_candidate_entry' do
+        expect(mock_entry_class2).to receive(:create).with(
+          hash_including(identity_principal_id: 42, access_scope: 'private')
+        ).and_return(mock_entry2)
+
+        host.handle_ingest(
+          content: 'test fact', tags: [],
+          identity_principal_id: 42, identity_id: 7, identity_canonical_name: 'alice',
+          access_scope: 'private'
+        )
+      end
+
+      it 'defaults access_scope to global when not provided' do
+        expect(mock_entry_class2).to receive(:create).with(
+          hash_including(access_scope: 'global')
+        ).and_return(mock_entry2)
+
+        host.handle_ingest(content: 'test fact', tags: [])
+      end
+
+      it 'persists identity_id and identity_canonical_name' do
+        expect(mock_entry_class2).to receive(:create).with(
+          hash_including(identity_id: 7, identity_canonical_name: 'alice')
+        ).and_return(mock_entry2)
+
+        host.handle_ingest(
+          content: 'test fact', tags: [],
+          identity_principal_id: 42, identity_id: 7, identity_canonical_name: 'alice',
+          access_scope: 'private'
+        )
+      end
+    end
+
+    context 'dedup: private entries from different principals are not deduplicated' do
+      let(:mock_entry_class3) { double('ApolloEntry3') }
+      let(:mock_expertise_class3) { double('ApolloExpertise3') }
+      let(:mock_access_log_class3) { double('ApolloAccessLog3') }
+      let(:mock_entry_a) { double('entry_a', id: 7, embedding: nil) }
+      let(:mock_entry_b) { double('entry_b', id: 8, embedding: nil) }
+
+      before do
+        stub_const('Legion::Data::Model::ApolloEntry', mock_entry_class3)
+        stub_const('Legion::Data::Model::ApolloExpertise', mock_expertise_class3)
+        stub_const('Legion::Data::Model::ApolloAccessLog', mock_access_log_class3)
+        allow(mock_expertise_class3).to receive(:where).and_return(double(first: nil))
+        allow(mock_expertise_class3).to receive(:create)
+        allow(mock_access_log_class3).to receive(:create)
+        allow(host).to receive(:embed_text).and_return(nil)
+        allow(host).to receive(:find_corroboration).and_return([false, nil])
+        allow(host).to receive(:detect_contradictions).and_return([])
+        # default dedup returns nil (no duplicate) — supports chained .where for private scope
+        scoped_ds3 = double('dedup_chain3', first: nil)
+        allow(scoped_ds3).to receive(:where).and_return(double('scoped_ds3b', first: nil))
+        allow(scoped_ds3).to receive(:exclude).and_return(scoped_ds3)
+        allow(mock_entry_class3).to receive(:where).and_return(scoped_ds3)
+        # two different principals each get their own entry
+        allow(mock_entry_class3).to receive(:create).and_return(mock_entry_a, mock_entry_b)
+      end
+
+      it 'does not deduplicate private entries from different principals' do
+        result1 = host.handle_ingest(content: 'same fact', content_type: :observation,
+                                     access_scope: 'private', identity_principal_id: 1)
+        result2 = host.handle_ingest(content: 'same fact', content_type: :observation,
+                                     access_scope: 'private', identity_principal_id: 2)
+        expect(result1[:entry_id]).not_to eq(result2[:entry_id])
+      end
+    end
+
     context 'early-return warn logs' do
       let(:logger) { instance_double('Logger', debug: nil, info: nil, warn: nil) }
 

--- a/spec/legion/extensions/apollo/runners/knowledge_spec.rb
+++ b/spec/legion/extensions/apollo/runners/knowledge_spec.rb
@@ -994,6 +994,18 @@ RSpec.describe Legion::Extensions::Apollo::Runners::Knowledge do
         expect(result[:redacted]).to eq(2)
         expect(result[:agent_id]).to eq('agent-dead')
       end
+
+      it 'clears identity columns on confirmed (redacted) entries' do
+        expect(mock_dataset).to receive(:update).with(
+          hash_including(
+            identity_principal_id:   nil,
+            identity_id:             nil,
+            identity_canonical_name: nil
+          )
+        ).and_return(2)
+
+        host.handle_erasure_request(agent_id: 'agent-dead')
+      end
     end
 
     context 'when Sequel raises an error' do

--- a/spec/legion/extensions/apollo/runners/knowledge_spec.rb
+++ b/spec/legion/extensions/apollo/runners/knowledge_spec.rb
@@ -610,6 +610,37 @@ RSpec.describe Legion::Extensions::Apollo::Runners::Knowledge do
         expect(dataset).to have_received(:where).with(knowledge_domain: 'general')
       end
     end
+
+    context 'access scope forwarding' do
+      let(:mock_entry_class) { double('ApolloEntry') }
+      let(:mock_db) { double('db') }
+
+      before do
+        stub_const('Legion::Data::Model::ApolloEntry', mock_entry_class)
+        allow(Legion::LLM::Call::Embeddings).to receive(:generate)
+          .and_return({ vector: Array.new(1024, 0.1), model: 'test', provider: :ollama, dimensions: 1024, tokens: 0 })
+        allow(mock_entry_class).to receive(:db).and_return(mock_db)
+        allow(mock_db).to receive(:fetch).and_return(double(all: []))
+        allow(mock_entry_class).to receive(:where).and_return(double(update: true))
+      end
+
+      it 'forwards requesting_principal_id to build_semantic_search_sql' do
+        expect(Legion::Extensions::Apollo::Helpers::GraphQuery).to receive(:build_semantic_search_sql).with(
+          hash_including(requesting_principal_id: 42)
+        ).and_return('SELECT 1')
+        allow(mock_db).to receive(:fetch).and_return(double(all: []))
+
+        host.handle_query(query: 'test', requesting_principal_id: 42)
+      end
+
+      it 'passes nil requesting_principal_id when not provided (no filter)' do
+        expect(Legion::Extensions::Apollo::Helpers::GraphQuery).to receive(:build_semantic_search_sql).with(
+          hash_including(requesting_principal_id: nil)
+        ).and_return('SELECT 1')
+
+        host.handle_query(query: 'test')
+      end
+    end
   end
 
   describe '#normalize_text_input' do
@@ -685,6 +716,14 @@ RSpec.describe Legion::Extensions::Apollo::Runners::Knowledge do
           hash_including(domain: 'clinical')
         ).and_call_original
         host.retrieve_relevant(query: 'treatment', domain: 'clinical')
+      end
+
+      it 'forwards requesting_principal_id to build_semantic_search_sql' do
+        expect(Legion::Extensions::Apollo::Helpers::GraphQuery).to receive(:build_semantic_search_sql).with(
+          hash_including(requesting_principal_id: 7)
+        ).and_return('SELECT 1')
+
+        host.retrieve_relevant(query: 'test', requesting_principal_id: 7)
       end
     end
   end


### PR DESCRIPTION
## Summary

- `handle_ingest` now accepts and persists `access_scope`, `identity_principal_id`, `identity_id`, `identity_canonical_name` to `apollo_entries` — populated automatically by legion-apollo's identity injection; defaults to `access_scope: 'global'` for backward compatibility
- `build_semantic_search_sql` adds optional access-scope SQL filter when `requesting_principal_id:` is provided: global always visible, private owner-only (dual-path for multi-provider auth via both `identity_principal_id` FK and `identities` subquery), team via group membership join
- `handle_query` and `retrieve_relevant` both accept and forward `requesting_principal_id:` — covers the GAIA path (via `handle_query`) and the direct-call path (via `retrieve_relevant`); browse-mode fallback (`list_entries_chronologically`) filtered too
- Private-entry dedup guard: when `access_scope: 'private'`, the content-hash dedup check is scoped per-principal so two different principals writing identical content each get their own row
- `handle_erasure_request` now clears `identity_principal_id`, `identity_id`, `identity_canonical_name` on confirmed entries — GDPR right-to-erasure compliance gap closed

## Prerequisites

- Phase 1 (legion-data migrations 100–124) merged and deployed — `apollo_entries` needs `access_scope`, `identity_principal_id`, `identity_id`, `identity_canonical_name` columns
- Phase 0 (legion-apollo identity injection) merged — `Legion::Apollo.ingest` already injects these kwargs

## Test plan

- [x] `handle_ingest` forwards identity kwargs and `access_scope` to `create_candidate_entry`
- [x] `handle_ingest` defaults `access_scope` to `'global'` when not provided
- [x] `handle_ingest` persists `identity_id` and `identity_canonical_name`
- [x] Private entries from different principals are not deduplicated (per-principal hash check)
- [x] `build_semantic_search_sql` without `requesting_principal_id` has no `access_scope` clause (backwards compatible)
- [x] `build_semantic_search_sql` with `requesting_principal_id` generates correct global/team/private SQL
- [x] `handle_query` forwards `requesting_principal_id` to `build_semantic_search_sql`
- [x] `retrieve_relevant` forwards `requesting_principal_id` to `build_semantic_search_sql`
- [x] `handle_erasure_request` clears identity FK columns on confirmed (redacted) entries
- [x] All 335 existing examples pass, 0 failures, rubocop clean